### PR TITLE
[feature/secondSection] secondSectionCell 생성  

### DIFF
--- a/K-Keyboard.xcodeproj/project.pbxproj
+++ b/K-Keyboard.xcodeproj/project.pbxproj
@@ -19,6 +19,8 @@
 		63487F4428E2EA5E0033CF32 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 63487F4228E2EA5E0033CF32 /* LaunchScreen.storyboard */; };
 		6426E6AA28E730EC00159D4A /* FirstSectionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6426E6A928E730EC00159D4A /* FirstSectionCell.swift */; };
 		64D6427528E938C000E475A5 /* SecondSectionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64D6427428E938C000E475A5 /* SecondSectionCell.swift */; };
+		64D6427828E97A1B00E475A5 /* TagCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64D6427728E97A1B00E475A5 /* TagCollectionViewCell.swift */; };
+		64D6427A28E981BE00E475A5 /* TagCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64D6427928E981BE00E475A5 /* TagCollectionView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -36,6 +38,8 @@
 		63487F4528E2EA5E0033CF32 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		6426E6A928E730EC00159D4A /* FirstSectionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstSectionCell.swift; sourceTree = "<group>"; };
 		64D6427428E938C000E475A5 /* SecondSectionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecondSectionCell.swift; sourceTree = "<group>"; };
+		64D6427728E97A1B00E475A5 /* TagCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagCollectionViewCell.swift; sourceTree = "<group>"; };
+		64D6427928E981BE00E475A5 /* TagCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagCollectionView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -121,6 +125,8 @@
 			isa = PBXGroup;
 			children = (
 				64D6427428E938C000E475A5 /* SecondSectionCell.swift */,
+				64D6427928E981BE00E475A5 /* TagCollectionView.swift */,
+				64D6427728E97A1B00E475A5 /* TagCollectionViewCell.swift */,
 			);
 			path = SecondSection;
 			sourceTree = "<group>";
@@ -199,9 +205,11 @@
 			buildActionMask = 2147483647;
 			files = (
 				63487F3C28E2EA5E0033CF32 /* FirstViewController.swift in Sources */,
+				64D6427828E97A1B00E475A5 /* TagCollectionViewCell.swift in Sources */,
 				64D6427528E938C000E475A5 /* SecondSectionCell.swift in Sources */,
 				63487F3828E2EA5E0033CF32 /* AppDelegate.swift in Sources */,
 				6426E6AA28E730EC00159D4A /* FirstSectionCell.swift in Sources */,
+				64D6427A28E981BE00E475A5 /* TagCollectionView.swift in Sources */,
 				63487F3A28E2EA5E0033CF32 /* SceneDelegate.swift in Sources */,
 				4019E21C28E5EB34007DD322 /* FourthSectionCell.swift in Sources */,
 				40478C3F28E6E67F00C96673 /* Const.swift in Sources */,

--- a/K-Keyboard.xcodeproj/project.pbxproj
+++ b/K-Keyboard.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		63487F4128E2EA5E0033CF32 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 63487F4028E2EA5E0033CF32 /* Assets.xcassets */; };
 		63487F4428E2EA5E0033CF32 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 63487F4228E2EA5E0033CF32 /* LaunchScreen.storyboard */; };
 		6426E6AA28E730EC00159D4A /* FirstSectionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6426E6A928E730EC00159D4A /* FirstSectionCell.swift */; };
+		64D6427528E938C000E475A5 /* SecondSectionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64D6427428E938C000E475A5 /* SecondSectionCell.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -34,6 +35,7 @@
 		63487F4328E2EA5E0033CF32 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		63487F4528E2EA5E0033CF32 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		6426E6A928E730EC00159D4A /* FirstSectionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstSectionCell.swift; sourceTree = "<group>"; };
+		64D6427428E938C000E475A5 /* SecondSectionCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecondSectionCell.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -60,6 +62,7 @@
 			children = (
 				63487F4228E2EA5E0033CF32 /* LaunchScreen.storyboard */,
 				6426E6A928E730EC00159D4A /* FirstSectionCell.swift */,
+				64D6427628E9562000E475A5 /* SecondSection */,
 				4019E21B28E5EB34007DD322 /* FourthSectionCell.swift */,
 			);
 			path = View;
@@ -112,6 +115,14 @@
 				40478C3E28E6E67F00C96673 /* Const.swift */,
 			);
 			path = "K-Keyboard";
+			sourceTree = "<group>";
+		};
+		64D6427628E9562000E475A5 /* SecondSection */ = {
+			isa = PBXGroup;
+			children = (
+				64D6427428E938C000E475A5 /* SecondSectionCell.swift */,
+			);
+			path = SecondSection;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -188,6 +199,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				63487F3C28E2EA5E0033CF32 /* FirstViewController.swift in Sources */,
+				64D6427528E938C000E475A5 /* SecondSectionCell.swift in Sources */,
 				63487F3828E2EA5E0033CF32 /* AppDelegate.swift in Sources */,
 				6426E6AA28E730EC00159D4A /* FirstSectionCell.swift in Sources */,
 				63487F3A28E2EA5E0033CF32 /* SceneDelegate.swift in Sources */,

--- a/K-Keyboard/Controller/FirstViewController.swift
+++ b/K-Keyboard/Controller/FirstViewController.swift
@@ -78,7 +78,7 @@ extension FirstViewController: UITableViewDelegate, UITableViewDataSource {
         switch indexPath.section {
         case 1:
             // MARK: Tag 수에 따라서 높이 계산해서 따로 설정해줘야 함
-            return CGFloat(100)
+            return CGFloat(144)
         default:
             return UITableView.automaticDimension
         }

--- a/K-Keyboard/Controller/FirstViewController.swift
+++ b/K-Keyboard/Controller/FirstViewController.swift
@@ -78,6 +78,7 @@ extension FirstViewController: UITableViewDelegate, UITableViewDataSource {
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         tableView.register(TestTableViewCellOne.self, forCellReuseIdentifier: TestTableViewCellOne.identifier)
         tableView.register(FirstSectionCell.self, forCellReuseIdentifier: FirstSectionCell.identifier)
+        tableView.register(SecondSectionCell.self, forCellReuseIdentifier: SecondSectionCell.identifier)
         tableView.register(FourthSectionCell.self, forCellReuseIdentifier: FourthSectionCell.identifier)
 
         switch indexPath.section {
@@ -88,6 +89,12 @@ extension FirstViewController: UITableViewDelegate, UITableViewDataSource {
 
             return cell
         case 1:
+            guard let cell = tableView.dequeueReusableCell(withIdentifier: SecondSectionCell.identifier, for: indexPath) as? SecondSectionCell else {
+                return UITableViewCell()
+            }
+            
+            return cell
+        case 2:
             guard let cell = tableView.dequeueReusableCell(withIdentifier: TestTableViewCellOne.identifier, for: indexPath) as? TestTableViewCellOne else {
                 return UITableViewCell()
             }

--- a/K-Keyboard/Controller/FirstViewController.swift
+++ b/K-Keyboard/Controller/FirstViewController.swift
@@ -31,8 +31,7 @@ class FirstViewController: UIViewController {
         self.view.backgroundColor = .white
         firstTableView.delegate = self
         firstTableView.dataSource = self
-        firstTableView.estimatedRowHeight = UITableView.automaticDimension
-        firstTableView.rowHeight = UITableView.automaticDimension
+        firstTableView.separatorStyle = .none
         
         addViews()
         setConstraints()
@@ -73,6 +72,16 @@ extension FirstViewController: UITableViewDelegate, UITableViewDataSource {
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return 1
+    }
+    
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        switch indexPath.section {
+        case 1:
+            // MARK: Tag 수에 따라서 높이 계산해서 따로 설정해줘야 함
+            return CGFloat(100)
+        default:
+            return UITableView.automaticDimension
+        }
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {

--- a/K-Keyboard/Resource/Assets.xcassets/사각형630.imageset/Contents.json
+++ b/K-Keyboard/Resource/Assets.xcassets/사각형630.imageset/Contents.json
@@ -5,7 +5,7 @@
       "scale" : "1x"
     },
     {
-      "filename" : "사각형630.pdf",
+      "filename" : "사각형630.pdf",
       "idiom" : "universal",
       "scale" : "2x"
     },

--- a/K-Keyboard/Resource/Assets.xcassets/사각형631.imageset/Contents.json
+++ b/K-Keyboard/Resource/Assets.xcassets/사각형631.imageset/Contents.json
@@ -5,7 +5,7 @@
       "scale" : "1x"
     },
     {
-      "filename" : "사각형631.pdf",
+      "filename" : "사각형631.pdf",
       "idiom" : "universal",
       "scale" : "2x"
     },

--- a/K-Keyboard/Resource/Assets.xcassets/자산 41@4x.imageset/Contents.json
+++ b/K-Keyboard/Resource/Assets.xcassets/자산 41@4x.imageset/Contents.json
@@ -1,7 +1,7 @@
 {
   "images" : [
     {
-      "filename" : "자산 41@4x.pdf",
+      "filename" : "자산 41@4x.pdf",
       "idiom" : "universal"
     }
   ],

--- a/K-Keyboard/View/SecondSection/SecondSectionCell.swift
+++ b/K-Keyboard/View/SecondSection/SecondSectionCell.swift
@@ -1,0 +1,123 @@
+//
+//  SecondSectionCell.swift
+//  K-Keyboard
+//
+//  Created by channy on 2022/10/02.
+//
+
+class SecondSectionCell: UITableViewCell, UICollectionViewDataSource {
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        self.items.count
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: TagCell.identifier, for: indexPath) as! TagCell
+        return cell
+    }
+    
+    static let identifier = "section2"
+    
+    var items: [String] = ["TEST1", "TEST2", "TEST3"]
+    
+    let collectionViewFlowLayout: UICollectionViewFlowLayout = {
+        let layout = UICollectionViewFlowLayout()
+        layout.scrollDirection = .horizontal
+        layout.minimumLineSpacing = 8.0
+        layout.minimumInteritemSpacing = 0
+        layout.itemSize = .init(width: 300, height: 300)
+        return layout
+    }()
+    
+    lazy var collectionView: UICollectionView = {
+        let view = UICollectionView(frame: .zero, collectionViewLayout: self.collectionViewFlowLayout)
+        view.isScrollEnabled = true
+        view.showsHorizontalScrollIndicator = false
+        view.showsVerticalScrollIndicator = true
+        view.contentInset = .zero
+        view.backgroundColor = .clear
+        view.register(TagCell.self, forCellWithReuseIdentifier: TagCell.identifier)
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+    
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        addViews()
+        setConstraints()
+        
+        self.collectionView.dataSource = self
+        
+        self.contentView.addSubview(self.collectionView)
+        
+        NSLayoutConstraint.activate([
+            self.collectionView.leftAnchor.constraint(equalTo: contentView.leftAnchor),
+            self.collectionView.rightAnchor.constraint(equalTo: contentView.rightAnchor),
+            self.collectionView.topAnchor.constraint(equalTo: contentView.topAnchor),
+            self.collectionView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor)
+        ])
+    }
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+    }
+
+    @available(*, unavailable)
+    required init?(coder _: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+extension SecondSectionCell {
+    func addViews() {
+        [].forEach {
+//            contentView.addSubview($0)
+        }
+    }
+    func setConstraints() {
+        [].forEach {
+//            $0.translatesAutoresizingMaskIntoConstraints = false
+        }
+        
+        NSLayoutConstraint.activate([
+        ])
+    }
+}
+
+class TagCell: UICollectionViewCell {
+    static let identifier = "tagCell"
+    
+    let tagLabel: UILabel = {
+        let label = UILabel()
+        label.text = "TEST"
+        label.font = .systemFont(ofSize: 14)
+        label.textColor = .gray
+        return label
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        contentView.addSubview(tagLabel)
+        
+        tagLabel.translatesAutoresizingMaskIntoConstraints =  false
+        tagLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor).isActive = true
+        tagLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor).isActive = true
+        tagLabel.topAnchor.constraint(equalTo: contentView.topAnchor).isActive = true
+        tagLabel.bottomAnchor.constraint(equalTo: contentView.bottomAnchor).isActive = true
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+#if canImport(SwiftUI) && DEBUG
+import SwiftUI
+struct SecondSectionCellPreview: PreviewProvider {
+    static var previews: some View {
+        UIViewPreview {
+            let cell = SecondSectionCell(frame: .zero)
+            return cell
+        }.previewLayout(.fixed(width: 343, height: 544))
+    }
+}
+#endif

--- a/K-Keyboard/View/SecondSection/SecondSectionCell.swift
+++ b/K-Keyboard/View/SecondSection/SecondSectionCell.swift
@@ -5,56 +5,23 @@
 //  Created by channy on 2022/10/02.
 //
 
-class SecondSectionCell: UITableViewCell, UICollectionViewDataSource {
-    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        self.items.count
-    }
-    
-    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: TagCell.identifier, for: indexPath) as! TagCell
-        return cell
-    }
-    
+import UIKit
+
+class SecondSectionCell: UITableViewCell {
+
     static let identifier = "section2"
+    var items: [String] = ["이벤트", "캐릭터", "새", "동물", "앙증맞은", "동글"]
     
-    var items: [String] = ["TEST1", "TEST2", "TEST3"]
-    
-    let collectionViewFlowLayout: UICollectionViewFlowLayout = {
-        let layout = UICollectionViewFlowLayout()
-        layout.scrollDirection = .horizontal
-        layout.minimumLineSpacing = 8.0
-        layout.minimumInteritemSpacing = 0
-        layout.itemSize = .init(width: 300, height: 300)
-        return layout
-    }()
-    
-    lazy var collectionView: UICollectionView = {
-        let view = UICollectionView(frame: .zero, collectionViewLayout: self.collectionViewFlowLayout)
-        view.isScrollEnabled = true
-        view.showsHorizontalScrollIndicator = false
-        view.showsVerticalScrollIndicator = true
-        view.contentInset = .zero
-        view.backgroundColor = .clear
-        view.register(TagCell.self, forCellWithReuseIdentifier: TagCell.identifier)
-        view.translatesAutoresizingMaskIntoConstraints = false
-        return view
-    }()
+    lazy var tagCollectionView: UICollectionView = TagCollectionView()
     
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         addViews()
         setConstraints()
         
-        self.collectionView.dataSource = self
+        self.tagCollectionView.dataSource = self
         
-        self.contentView.addSubview(self.collectionView)
-        
-        NSLayoutConstraint.activate([
-            self.collectionView.leftAnchor.constraint(equalTo: contentView.leftAnchor),
-            self.collectionView.rightAnchor.constraint(equalTo: contentView.rightAnchor),
-            self.collectionView.topAnchor.constraint(equalTo: contentView.topAnchor),
-            self.collectionView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor)
-        ])
+        self.contentView.addSubview(self.tagCollectionView)
     }
     
     override func prepareForReuse() {
@@ -69,44 +36,55 @@ class SecondSectionCell: UITableViewCell, UICollectionViewDataSource {
 
 extension SecondSectionCell {
     func addViews() {
-        [].forEach {
-//            contentView.addSubview($0)
+        [tagCollectionView].forEach {
+            contentView.addSubview($0)
         }
     }
     func setConstraints() {
-        [].forEach {
-//            $0.translatesAutoresizingMaskIntoConstraints = false
+        [tagCollectionView].forEach {
+            $0.translatesAutoresizingMaskIntoConstraints = false
         }
         
         NSLayoutConstraint.activate([
+            tagCollectionView.leftAnchor.constraint(equalTo: contentView.leftAnchor),
+            tagCollectionView.rightAnchor.constraint(equalTo: contentView.rightAnchor),
+            tagCollectionView.topAnchor.constraint(equalTo: contentView.topAnchor),
+            tagCollectionView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor)
         ])
     }
 }
 
-class TagCell: UICollectionViewCell {
-    static let identifier = "tagCell"
-    
-    let tagLabel: UILabel = {
-        let label = UILabel()
-        label.text = "TEST"
-        label.font = .systemFont(ofSize: 14)
-        label.textColor = .gray
-        return label
-    }()
-    
-    override init(frame: CGRect) {
-        super.init(frame: frame)
-        contentView.addSubview(tagLabel)
-        
-        tagLabel.translatesAutoresizingMaskIntoConstraints =  false
-        tagLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor).isActive = true
-        tagLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor).isActive = true
-        tagLabel.topAnchor.constraint(equalTo: contentView.topAnchor).isActive = true
-        tagLabel.bottomAnchor.constraint(equalTo: contentView.bottomAnchor).isActive = true
+extension SecondSectionCell: UICollectionViewDataSource {
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        self.items.count
     }
     
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        self.tagCollectionView.register(TagCollectionViewCell.self, forCellWithReuseIdentifier: TagCollectionViewCell.identifier)
+        
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: TagCollectionViewCell.identifier, for: indexPath) as? TagCollectionViewCell else {
+            return UICollectionViewCell()
+        }
+        
+        cell.tagLabel.text = self.items[indexPath.row]
+        return cell
+    }
+}
+
+extension SecondSectionCell: UICollectionViewDelegateFlowLayout {
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        let label: UILabel = {
+            let label = UILabel()
+            label.font = UIFont(name: "NotoSansKR-Medium", size: 14)
+            label.text = self.items[indexPath.row]
+            return label
+        }()
+        
+        let size = label.frame.size
+        let widthMargin = 10.3
+        let heightMargin = 4.0
+        
+        return CGSize(width: size.width + (2 * widthMargin), height: size.height + (2 * heightMargin))
     }
 }
 

--- a/K-Keyboard/View/SecondSection/SecondSectionCell.swift
+++ b/K-Keyboard/View/SecondSection/SecondSectionCell.swift
@@ -10,7 +10,17 @@ import UIKit
 class SecondSectionCell: UITableViewCell {
 
     static let identifier = "section2"
-    var items: [String] = ["이벤트", "캐릭터", "새", "동물", "앙증맞은", "동글"]
+    var items: [String] = ["이벤트", "캐릭터", "새", "동물", "앙증맞은", "동글동글"]
+    
+    let tagLabel: UILabel = {
+        let label = UILabel()
+        label.textColor = UIColor(red: 0.259, green: 0.267, blue: 0.298, alpha: 1)
+        label.font = UIFont(name: "NotoSansKR-Bold", size: 16)
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.lineHeightMultiple = 1.01
+        label.attributedText = NSMutableAttributedString(string: "태그", attributes: [NSAttributedString.Key.paragraphStyle: paragraphStyle])
+        return label
+    }()
     
     lazy var tagCollectionView: UICollectionView = TagCollectionView()
     
@@ -19,9 +29,8 @@ class SecondSectionCell: UITableViewCell {
         addViews()
         setConstraints()
         
+        self.tagCollectionView.delegate = self
         self.tagCollectionView.dataSource = self
-        
-        self.contentView.addSubview(self.tagCollectionView)
     }
     
     override func prepareForReuse() {
@@ -36,19 +45,22 @@ class SecondSectionCell: UITableViewCell {
 
 extension SecondSectionCell {
     func addViews() {
-        [tagCollectionView].forEach {
+        [tagLabel, tagCollectionView].forEach {
             contentView.addSubview($0)
         }
     }
+    
     func setConstraints() {
-        [tagCollectionView].forEach {
+        [tagLabel, tagCollectionView].forEach {
             $0.translatesAutoresizingMaskIntoConstraints = false
         }
         
         NSLayoutConstraint.activate([
-            tagCollectionView.leftAnchor.constraint(equalTo: contentView.leftAnchor),
-            tagCollectionView.rightAnchor.constraint(equalTo: contentView.rightAnchor),
-            tagCollectionView.topAnchor.constraint(equalTo: contentView.topAnchor),
+            tagLabel.leftAnchor.constraint(equalTo: contentView.leftAnchor, constant: 16),
+            tagLabel.topAnchor.constraint(equalTo: contentView.topAnchor),
+            tagCollectionView.leftAnchor.constraint(equalTo: contentView.leftAnchor, constant: 16),
+            tagCollectionView.rightAnchor.constraint(equalTo: contentView.rightAnchor, constant: -16),
+            tagCollectionView.topAnchor.constraint(equalTo: tagLabel.bottomAnchor, constant: 16),
             tagCollectionView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor)
         ])
     }
@@ -77,13 +89,14 @@ extension SecondSectionCell: UICollectionViewDelegateFlowLayout {
             let label = UILabel()
             label.font = UIFont(name: "NotoSansKR-Medium", size: 14)
             label.text = self.items[indexPath.row]
+            label.sizeToFit()
             return label
         }()
-        
+
         let size = label.frame.size
-        let widthMargin = 10.3
-        let heightMargin = 4.0
-        
+        let widthMargin: CGFloat = 10.3
+        let heightMargin: CGFloat = 4.0
+
         return CGSize(width: size.width + (2 * widthMargin), height: size.height + (2 * heightMargin))
     }
 }

--- a/K-Keyboard/View/SecondSection/TagCollectionView.swift
+++ b/K-Keyboard/View/SecondSection/TagCollectionView.swift
@@ -1,0 +1,27 @@
+//
+//  TagCollectionView.swift
+//  K-Keyboard
+//
+//  Created by channy on 2022/10/02.
+//
+
+import UIKit
+
+class TagCollectionView: UICollectionView {
+    override init(frame: CGRect, collectionViewLayout layout: UICollectionViewLayout) {
+        let collectionViewFlowLayout: UICollectionViewFlowLayout = {
+            let layout = UICollectionViewFlowLayout()
+            layout.scrollDirection = .horizontal
+            layout.minimumLineSpacing = 8.0
+            layout.minimumInteritemSpacing = 0
+            return layout
+        }()
+        super.init(frame: .zero, collectionViewLayout: collectionViewFlowLayout)
+    }
+    
+    @available(*, unavailable)
+    required init?(coder _: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+

--- a/K-Keyboard/View/SecondSection/TagCollectionView.swift
+++ b/K-Keyboard/View/SecondSection/TagCollectionView.swift
@@ -10,13 +10,15 @@ import UIKit
 class TagCollectionView: UICollectionView {
     override init(frame: CGRect, collectionViewLayout layout: UICollectionViewLayout) {
         let collectionViewFlowLayout: UICollectionViewFlowLayout = {
-            let layout = UICollectionViewFlowLayout()
-            layout.scrollDirection = .horizontal
-            layout.minimumLineSpacing = 8.0
-            layout.minimumInteritemSpacing = 0
+            let layout = LeftAlignedCollectionViewFlowLayout()
+            layout.minimumLineSpacing = 8
+            layout.minimumInteritemSpacing = 4.12
+            layout.sectionInset = UIEdgeInsets(top: 5, left: 2, bottom: 5, right: 2)
             return layout
         }()
+        
         super.init(frame: .zero, collectionViewLayout: collectionViewFlowLayout)
+        self.isScrollEnabled = false
     }
     
     @available(*, unavailable)
@@ -25,3 +27,22 @@ class TagCollectionView: UICollectionView {
     }
 }
 
+class LeftAlignedCollectionViewFlowLayout: UICollectionViewFlowLayout {
+    override func layoutAttributesForElements(in rect: CGRect) -> [UICollectionViewLayoutAttributes]? {
+        let attributes = super.layoutAttributesForElements(in: rect)
+        
+        var leftMargin = sectionInset.left
+        var maxY: CGFloat = -1.0
+        attributes?.forEach { layoutAttribute in
+            if layoutAttribute.representedElementCategory == .cell {
+                if layoutAttribute.frame.origin.y >= maxY {
+                    leftMargin = sectionInset.left
+                }
+                layoutAttribute.frame.origin.x = leftMargin
+                leftMargin += layoutAttribute.frame.width + minimumInteritemSpacing
+                maxY = max(layoutAttribute.frame.maxY, maxY)
+            }
+        }
+        return attributes
+    }
+}

--- a/K-Keyboard/View/SecondSection/TagCollectionView.swift
+++ b/K-Keyboard/View/SecondSection/TagCollectionView.swift
@@ -13,7 +13,6 @@ class TagCollectionView: UICollectionView {
             let layout = LeftAlignedCollectionViewFlowLayout()
             layout.minimumLineSpacing = 8
             layout.minimumInteritemSpacing = 4.12
-            layout.sectionInset = UIEdgeInsets(top: 5, left: 2, bottom: 5, right: 2)
             return layout
         }()
         

--- a/K-Keyboard/View/SecondSection/TagCollectionViewCell.swift
+++ b/K-Keyboard/View/SecondSection/TagCollectionViewCell.swift
@@ -1,0 +1,41 @@
+//
+//  TagCollectionViewCell.swift
+//  K-Keyboard
+//
+//  Created by channy on 2022/10/02.
+//
+
+import UIKit
+
+class TagCollectionViewCell: UICollectionViewCell {
+    static let identifier = "tagCell"
+    
+    var items: [String]?
+
+    let tagLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont(name: "NotoSansKR-Medium", size: 14)
+        label.textColor = UIColor(red: 0.294, green: 0.306, blue: 0.341, alpha: 1)
+        label.textAlignment = .center
+        return label
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        contentView.addSubview(tagLabel)
+        
+        contentView.layer.backgroundColor = UIColor(red: 0.922, green: 0.929, blue: 0.961, alpha: 1).cgColor
+        contentView.layer.masksToBounds = true
+        contentView.layer.cornerRadius = 18
+        
+        tagLabel.translatesAutoresizingMaskIntoConstraints =  false
+        tagLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor).isActive = true
+        tagLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor).isActive = true
+        tagLabel.topAnchor.constraint(equalTo: contentView.topAnchor).isActive = true
+        tagLabel.bottomAnchor.constraint(equalTo: contentView.bottomAnchor).isActive = true
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/K-Keyboard/View/SecondSection/TagCollectionViewCell.swift
+++ b/K-Keyboard/View/SecondSection/TagCollectionViewCell.swift
@@ -22,20 +22,36 @@ class TagCollectionViewCell: UICollectionViewCell {
     
     override init(frame: CGRect) {
         super.init(frame: frame)
-        contentView.addSubview(tagLabel)
+        addViews()
+        setConstraints()
         
         contentView.layer.backgroundColor = UIColor(red: 0.922, green: 0.929, blue: 0.961, alpha: 1).cgColor
         contentView.layer.masksToBounds = true
         contentView.layer.cornerRadius = 18
-        
-        tagLabel.translatesAutoresizingMaskIntoConstraints =  false
-        tagLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor).isActive = true
-        tagLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor).isActive = true
-        tagLabel.topAnchor.constraint(equalTo: contentView.topAnchor).isActive = true
-        tagLabel.bottomAnchor.constraint(equalTo: contentView.bottomAnchor).isActive = true
     }
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+}
+
+extension TagCollectionViewCell {
+    func addViews() {
+        [tagLabel].forEach {
+            contentView.addSubview($0)
+        }
+    }
+    
+    func setConstraints() {
+        [tagLabel].forEach {
+            $0.translatesAutoresizingMaskIntoConstraints = false
+        }
+        
+        NSLayoutConstraint.activate([
+            tagLabel.leftAnchor.constraint(equalTo: contentView.leftAnchor),
+            tagLabel.rightAnchor.constraint(equalTo: contentView.rightAnchor),
+            tagLabel.topAnchor.constraint(equalTo: contentView.topAnchor),
+            tagLabel.bottomAnchor.constraint(equalTo: contentView.bottomAnchor)
+        ])
     }
 }


### PR DESCRIPTION
# [feature/secondSection] secondSectionCell 생성  
## 개발 환경  
* Xcode 14.0.1  
* iOS 16.0  
* iPhone 14 pro (Simulator)  

## 상세 설명   
<img width="300" alt="section2" src="https://user-images.githubusercontent.com/63276842/193520322-8adf3b31-b4e3-4eed-8e8d-41912b083467.png">  

* 구현한 파트  
  * `TagCollectionView` : 태그들을 표시하는 collectionView  
  * `TagCollectionViewCell` : 각각의 태그를 나타내는 collectionViewCell  
  * `LeftAlignedCollectionViewFlowLayout` : collectionView 내부의 cell 들을 왼쪽 정렬 시키기 위한 flow layout  
  * `SecondSectionCell` 에 `tagCollectionView` 를 넣어서 구현  

## 리팩토링 필요한 부분  
* 현재는 태그 생성 시에 `collectionView` 의 데이터로 접근하는데, model 형태로 받아올 수 있도록 구조 변경이 필요함  
* `collectionView` 의 `height` 를 동적으로 만들기 위해서는 제약조건이 필요함  
  * width 와 height 를 모두 동적으로 처리할 수 있는 방법이 있을까?  